### PR TITLE
Fixes Universe Selection Time

### DIFF
--- a/QuantConnect.DataSource.csproj
+++ b/QuantConnect.DataSource.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="QuantConnect.Common" Version="2.5.*" />
-    <PackageReference Include="protobuf-net" Version="3.0.29" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/QuiverTwitterFollowers.cs
+++ b/QuiverTwitterFollowers.cs
@@ -32,39 +32,31 @@ namespace QuantConnect.DataSource
     [ProtoContract(SkipConstructor = true)]
     public class QuiverTwitterFollowers : BaseData
     {
+        private readonly TimeSpan _period = TimeSpan.FromDays(1);
+
         /// <summary>
         /// Number of followers of the company's Twitter page on the given date
         /// </summary>
-        [ProtoMember(12)]
         [JsonProperty(PropertyName = "Followers")]
         public int Followers { get; set; }
 
         /// <summary>
         /// Day-over-day change in company's follower count
         /// </summary>
-        [ProtoMember(13)]
         [JsonProperty(PropertyName = "pct_change_day")]
         public decimal DayPercentChange { get; set; }
 
         /// <summary>
         /// Week-over-week change in company's follower count
         /// </summary>
-        [ProtoMember(14)]
         [JsonProperty(PropertyName = "pct_change_week")]
         public decimal WeekPercentChange { get; set; }
 
         /// <summary>
         /// Month-over-month change in company's follower count
         /// </summary>
-        [ProtoMember(15)]
         [JsonProperty(PropertyName = "pct_change_month")]
         public decimal MonthPercentChange { get; set; }
-
-        /// <summary>
-        /// Time passed between the date of the data and the time the data became available to us
-        /// </summary>
-        [ProtoMember(16)]
-        public TimeSpan Period { get; set; } = TimeSpan.FromDays(1);
 
         /// <summary>
         /// Current time marker of this data packet.
@@ -78,7 +70,7 @@ namespace QuantConnect.DataSource
         /// <summary>
         /// Time the data became available
         /// </summary>
-        public override DateTime EndTime => Time + Period;
+        public override DateTime EndTime => Time + _period;
 
         /// <summary>
         /// Return the URL string source of the file. This will be converted to a stream

--- a/QuiverTwitterFollowers.cs
+++ b/QuiverTwitterFollowers.cs
@@ -30,7 +30,7 @@ namespace QuantConnect.DataSource
     /// </summary>
     public class QuiverTwitterFollowers : BaseData
     {
-        private readonly TimeSpan _period = TimeSpan.FromDays(1);
+        private static readonly TimeSpan _period = TimeSpan.FromDays(1);
 
         /// <summary>
         /// Number of followers of the company's Twitter page on the given date

--- a/QuiverTwitterFollowers.cs
+++ b/QuiverTwitterFollowers.cs
@@ -20,7 +20,6 @@ using System.Globalization;
 using System.IO;
 using Newtonsoft.Json;
 using NodaTime;
-using ProtoBuf;
 using QuantConnect.Data;
 using QuantConnect.Util;
 
@@ -29,7 +28,6 @@ namespace QuantConnect.DataSource
     /// <summary>
     /// Example custom data type
     /// </summary>
-    [ProtoContract(SkipConstructor = true)]
     public class QuiverTwitterFollowers : BaseData
     {
         private readonly TimeSpan _period = TimeSpan.FromDays(1);
@@ -62,7 +60,6 @@ namespace QuantConnect.DataSource
         /// Current time marker of this data packet.
         /// </summary>
         /// <remarks>All data is timeseries based.</remarks>
-        [ProtoMember(2)]
         [JsonProperty(PropertyName = "Date")]
         [JsonConverter(typeof(DateTimeJsonConverter), "yyyy-MM-dd")]
         public new DateTime Time { get; set; }

--- a/QuiverTwitterFollowersUniverse.cs
+++ b/QuiverTwitterFollowersUniverse.cs
@@ -28,7 +28,7 @@ namespace QuantConnect.DataSource
     /// </summary>
     public class QuiverTwitterFollowersUniverse : BaseData
     {
-        private readonly TimeSpan _period = TimeSpan.FromDays(1);
+        private static readonly TimeSpan _period = TimeSpan.FromDays(1);
 
         /// <summary>
         /// Number of followers of the company's Twitter page on the given date

--- a/QuiverTwitterFollowersUniverse.cs
+++ b/QuiverTwitterFollowersUniverse.cs
@@ -28,6 +28,8 @@ namespace QuantConnect.DataSource
     /// </summary>
     public class QuiverTwitterFollowersUniverse : BaseData
     {
+        private readonly TimeSpan _period = TimeSpan.FromDays(1);
+
         /// <summary>
         /// Number of followers of the company's Twitter page on the given date
         /// </summary>
@@ -49,14 +51,9 @@ namespace QuantConnect.DataSource
         public decimal MonthPercentChange { get; set; }
 
         /// <summary>
-        /// Time passed between the date of the data and the time the data became available to us
-        /// </summary>
-        public TimeSpan Period { get; set; } = TimeSpan.FromDays(1);
-
-        /// <summary>
         /// Time the data became available
         /// </summary>
-        public override DateTime EndTime => Time + Period;
+        public override DateTime EndTime => Time + _period;
 
         /// <summary>
         /// Return the URL string source of the file. This will be converted to a stream
@@ -101,7 +98,7 @@ namespace QuantConnect.DataSource
                 MonthPercentChange = decimal.Parse(csv[5], NumberStyles.Any, CultureInfo.InvariantCulture),
 
                 Symbol = new Symbol(SecurityIdentifier.Parse(csv[0]), csv[1]),
-                Time = date - Period,
+                Time = date,
                 Value = followers
             };
         }

--- a/tests/QuiverTwitterFollowersTests.cs
+++ b/tests/QuiverTwitterFollowersTests.cs
@@ -43,26 +43,6 @@ namespace QuantConnect.DataLibrary.Tests
         }
 
         [Test]
-        public void ProtobufRoundTrip()
-        {
-            var expected = CreateNewInstance();
-            var type = expected.GetType();
-
-            RuntimeTypeModel.Default[typeof(BaseData)].AddSubType(2000, type);
-
-            using (var stream = new MemoryStream())
-            {
-                Serializer.Serialize(stream, expected);
-
-                stream.Position = 0;
-
-                var result = Serializer.Deserialize(type, stream);
-
-                AssertAreEqual(expected, result, filterByCustomAttributes: true);
-            }
-        }
-
-        [Test]
         public void Clone()
         {
             var expected = CreateNewInstance();

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -10,7 +10,6 @@
     <None Include="..\QuiverTwitterFollowersUniverseSelectionAlgorithm.py" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="protobuf-net" Version="3.0.29" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
- Removes [ProtoMember] of QuiverTwitterFollowers Class:

    - Unnecessary since this data is not streamed.
    - Change `Period` access from `public` to `readonly private`.

- Fixes Universe Selection Time
    - We were subtracting the period when we should not.
    - Change `Period` access from public to readonly private.
   - Change the Universe Selection algorithm to add a sanity check.
