### PR TITLE
Fix data processor to adapt new JSON format

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    container:
-        image: quantconnect/lean:foundation
+    
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Free space
+        run: df -h && rm -rf /opt/hostedtoolcache* && df -h
+
+      - name: Pull Foundation Image
+        uses: addnab/docker-run-action@v3
+        with:
+          image: quantconnect/lean:foundation
 
       - name: Checkout Lean Same Branch
         id: lean-same-branch

--- a/DataProcessing/QuiverTwitterFollowersDataDownloader.cs
+++ b/DataProcessing/QuiverTwitterFollowersDataDownloader.cs
@@ -150,19 +150,16 @@ namespace QuantConnect.DataProcessing
                                     {
                                         var dateTime = twitterDataPoint.Time;
                                         var date = $"{dateTime:yyyyMMdd}";
-                                        var follower = twitterDataPoint.Followers;
-                                        var dayChange = twitterDataPoint.DayPercentChange;
-                                        var weekChange = twitterDataPoint.WeekPercentChange;
-                                        var monthChange = twitterDataPoint.MonthPercentChange;
+                                        var info = ParseInfo(twitterDataPoint);
 
-                                        csvContents.Add($"{date},{follower},{dayChange},{weekChange},{monthChange}");
+                                        csvContents.Add($"{date},{info}");
 
                                         if (!_canCreateUniverseFiles)
                                             continue;
                                         
                                         var sid = SecurityIdentifier.GenerateEquity(ticker, Market.USA, true, mapFileProvider, dateTime);
 
-                                        var universeCsvContents = $"{sid},{ticker},{follower},{dayChange},{weekChange},{monthChange}";
+                                        var universeCsvContents = $"{sid},{ticker},{info}";
 
                                         var queue = _tempData.GetOrAdd(date, new ConcurrentQueue<string>()); 
                                         queue.Enqueue(universeCsvContents);
@@ -218,6 +215,15 @@ namespace QuantConnect.DataProcessing
 
             Log.Trace($"QuiverTwitterFollowersDataDownloader.Run(): Finished in {stopwatch.Elapsed.ToStringInvariant(null)}");
             return true;
+        }
+
+        public static string ParseInfo(QuiverTwitterFollowers twitterDataPoint)
+        {
+            var follower = twitterDataPoint.Followers;
+            var dayChange = twitterDataPoint.DayPercentChange;
+            var weekChange = twitterDataPoint.WeekPercentChange;
+            var monthChange = twitterDataPoint.MonthPercentChange;
+            return $"{follower},{dayChange},{weekChange},{monthChange}";
         }
 
         /// <summary>

--- a/DataProcessing/process.py
+++ b/DataProcessing/process.py
@@ -58,7 +58,7 @@ class QuiverTwitterFollowersDataDownloader:
                     for row in sorted(ticker_twitter, key=lambda x: x['Date']):
                         date_time = datetime.strptime(row['Date'], '%Y-%m-%d')
                         date = date_time.strftime('%Y%m%d') # 2020-05-08
-                        info = f"{row['Followers']},{row['pct_change_day']},{row['pct_change_week']},{row['pct_change_month']}"
+                        info = self.ParseJson(row)
 
                         lines.append(','.join([date, info]))
                 
@@ -77,6 +77,17 @@ class QuiverTwitterFollowersDataDownloader:
                     print(f'{e} - Failed to parse data for {ticker} - Retrying')
                     sleep(30)
                     trial -= 1
+                    
+    def ParseJson(self, entry):
+        pct_change_daily = self.ParseValue(entry['pct_change_daily'])
+        pct_change_week = self.ParseValue(entry['pct_change_week'])
+        pct_change_month = self.ParseValue(entry['pct_change'])
+        return f"{entry['Followers']},{pct_change_daily},{pct_change_week},{pct_change_month}"
+                    
+    def ParseValue(self, property):
+        if property and str(property).lower() != "nan":
+            return property
+        return ""
 
     def HttpRequester(self, url):       
         base_url = 'https://api.quiverquant.com/beta'

--- a/QuiverTwitterFollowers.cs
+++ b/QuiverTwitterFollowers.cs
@@ -42,19 +42,19 @@ namespace QuantConnect.DataSource
         /// Day-over-day change in company's follower count
         /// </summary>
         [JsonProperty(PropertyName = "pct_change_daily")]
-        public decimal DayPercentChange { get; set; }
+        public decimal? DayPercentChange { get; set; }
 
         /// <summary>
         /// Week-over-week change in company's follower count
         /// </summary>
         [JsonProperty(PropertyName = "pct_change_week")]
-        public decimal WeekPercentChange { get; set; }
+        public decimal? WeekPercentChange { get; set; }
 
         /// <summary>
         /// Month-over-month change in company's follower count
         /// </summary>
         [JsonProperty(PropertyName = "pct_change")]
-        public decimal MonthPercentChange { get; set; }
+        public decimal? MonthPercentChange { get; set; }
 
         /// <summary>
         /// Current time marker of this data packet.
@@ -110,9 +110,9 @@ namespace QuantConnect.DataSource
                 Value = followers,
  
                 Followers = followers,
-                DayPercentChange = decimal.Parse(csv[2], NumberStyles.Any, CultureInfo.InvariantCulture),
-                WeekPercentChange = decimal.Parse(csv[3], NumberStyles.Any, CultureInfo.InvariantCulture),
-                MonthPercentChange = decimal.Parse(csv[4], NumberStyles.Any, CultureInfo.InvariantCulture)
+                DayPercentChange = csv[2].IfNotNullOrEmpty<decimal?>(s => decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture)),
+                WeekPercentChange = csv[3].IfNotNullOrEmpty<decimal?>(s => decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture)),
+                MonthPercentChange = csv[4].IfNotNullOrEmpty<decimal?>(s => decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture))
             };
         }
 

--- a/QuiverTwitterFollowers.cs
+++ b/QuiverTwitterFollowers.cs
@@ -41,7 +41,7 @@ namespace QuantConnect.DataSource
         /// <summary>
         /// Day-over-day change in company's follower count
         /// </summary>
-        [JsonProperty(PropertyName = "pct_change_day")]
+        [JsonProperty(PropertyName = "pct_change_daily")]
         public decimal DayPercentChange { get; set; }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace QuantConnect.DataSource
         /// <summary>
         /// Month-over-month change in company's follower count
         /// </summary>
-        [JsonProperty(PropertyName = "pct_change_month")]
+        [JsonProperty(PropertyName = "pct_change")]
         public decimal MonthPercentChange { get; set; }
 
         /// <summary>

--- a/QuiverTwitterFollowersUniverse.cs
+++ b/QuiverTwitterFollowersUniverse.cs
@@ -38,17 +38,17 @@ namespace QuantConnect.DataSource
         /// <summary>
         /// Day-over-day change in company's follower count
         /// </summary>
-        public decimal DayPercentChange { get; set; }
+        public decimal? DayPercentChange { get; set; }
 
         /// <summary>
         /// Week-over-week change in company's follower count
         /// </summary>
-        public decimal WeekPercentChange { get; set; }
+        public decimal? WeekPercentChange { get; set; }
 
         /// <summary>
         /// Month-over-month change in company's follower count
         /// </summary>
-        public decimal MonthPercentChange { get; set; }
+        public decimal? MonthPercentChange { get; set; }
 
         /// <summary>
         /// Time the data became available
@@ -93,9 +93,9 @@ namespace QuantConnect.DataSource
             return new QuiverTwitterFollowersUniverse
             {
                 Followers = followers,
-                DayPercentChange = decimal.Parse(csv[3], NumberStyles.Any, CultureInfo.InvariantCulture),
-                WeekPercentChange = decimal.Parse(csv[4], NumberStyles.Any, CultureInfo.InvariantCulture),
-                MonthPercentChange = decimal.Parse(csv[5], NumberStyles.Any, CultureInfo.InvariantCulture),
+                DayPercentChange = csv[3].IfNotNullOrEmpty<decimal?>(s => decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture)),
+                WeekPercentChange = csv[4].IfNotNullOrEmpty<decimal?>(s => decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture)),
+                MonthPercentChange = csv[5].IfNotNullOrEmpty<decimal?>(s => decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture)),
 
                 Symbol = new Symbol(SecurityIdentifier.Parse(csv[0]), csv[1]),
                 Time = date,

--- a/tests/QuiverTwitterFollowersTests.cs
+++ b/tests/QuiverTwitterFollowersTests.cs
@@ -57,6 +57,21 @@ namespace QuantConnect.DataLibrary.Tests
             Assert.DoesNotThrow(() => instance.Reader(config, "20201104,1093260,9.14696e-05,-0.0254220704,-0.1202292029", DateTime.Today, false));
         }
 
+        [Test]
+        public void ReaderNaNTest()
+        {
+            var factory = new QuiverTwitterFollowers();
+            var line = "20201104,1093260,,,";
+
+            var symbol = Symbol.Create("SPY", SecurityType.Base, Market.USA);
+            var config = new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Daily, DateTimeZone.Utc, DateTimeZone.Utc, false, false, false); 
+            var date = new DateTime(2020, 11, 4);
+            var data = (QuiverTwitterFollowers)factory.Reader(config, line, date, false);
+            Assert.IsNull(data.DayPercentChange);
+            Assert.IsNull(data.WeekPercentChange);
+            Assert.IsNull(data.MonthPercentChange);
+        }
+
         private void AssertAreEqual(object expected, object result, bool filterByCustomAttributes = false)
         {
             foreach (var propertyInfo in expected.GetType().GetProperties())

--- a/tests/QuiverTwitterFollowersTests.cs
+++ b/tests/QuiverTwitterFollowersTests.cs
@@ -23,6 +23,7 @@ using Newtonsoft.Json;
 using NodaTime;
 using NUnit.Framework;
 using QuantConnect.Data;
+using QuantConnect.DataProcessing;
 using QuantConnect.DataSource;
 using QuantConnect.Data.Market;
 
@@ -31,6 +32,29 @@ namespace QuantConnect.DataLibrary.Tests
     [TestFixture]
     public class QuiverTwitterFollowersTests
     {
+        private readonly JsonSerializerSettings _jsonSerializerSettings = new()
+        {
+            DateTimeZoneHandling = DateTimeZoneHandling.Utc
+        };
+
+        [Test]
+        public void DeserializeObject()
+        {
+            var data = @"{
+                ""Date"": ""2020-01-01"",
+                ""Follower"": 1000,
+                ""pct_change_daily"": 5,
+                ""pct_change_week"": 100,
+                ""pct_change"": 10000,
+            }";
+            var twitterData = JsonConvert.DeserializeObject<QuiverTwitterFollowers>(data,
+                                _jsonSerializerSettings);
+            var result = QuiverTwitterFollowersDataDownloader.ParseInfo(twitterData);
+            var expected = CreateNewInstance();
+            
+            AssertAreEqual(expected, result);
+        }
+
         [Test]
         public void JsonRoundTrip()
         {

--- a/tests/QuiverTwitterFollowersTests.cs
+++ b/tests/QuiverTwitterFollowersTests.cs
@@ -45,7 +45,7 @@ namespace QuantConnect.DataLibrary.Tests
                 ""Follower"": 1000,
                 ""pct_change_daily"": 5,
                 ""pct_change_week"": 100,
-                ""pct_change"": 10000,
+                ""pct_change"": 10000
             }";
             var twitterData = JsonConvert.DeserializeObject<QuiverTwitterFollowers>(data,
                                 _jsonSerializerSettings);

--- a/tests/QuiverTwitterFollowersUniverseTests.cs
+++ b/tests/QuiverTwitterFollowersUniverseTests.cs
@@ -15,17 +15,12 @@
 */
 
 using System;
-using ProtoBuf;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using ProtoBuf.Meta;
 using Newtonsoft.Json;
-using NodaTime;
 using NUnit.Framework;
 using QuantConnect.Data;
 using QuantConnect.DataSource;
-using QuantConnect.Data.Market;
 
 namespace QuantConnect.DataLibrary.Tests
 {

--- a/tests/QuiverTwitterFollowersUniverseTests.cs
+++ b/tests/QuiverTwitterFollowersUniverseTests.cs
@@ -51,6 +51,19 @@ namespace QuantConnect.DataLibrary.Tests
             AssertAreEqual(expected, result);
         }
 
+        [Test]
+        public void ReaderNaNTest()
+        {
+            var factory = new QuiverTwitterFollowersUniverse();
+            var line = "A RPTMYV3VC57P,A,1093260,,,";
+
+            var date = DateTime.Today;
+            var data = (QuiverTwitterFollowersUniverse)factory.Reader(null, line, date, false);
+            Assert.IsNull(data.DayPercentChange);
+            Assert.IsNull(data.WeekPercentChange);
+            Assert.IsNull(data.MonthPercentChange);
+        }
+
         private void AssertAreEqual(object expected, object result, bool filterByCustomAttributes = false)
         {
             foreach (var propertyInfo in expected.GetType().GetProperties())

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="QuantConnect.Algorithm" Version="2.5.*" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\DataProcessing\DataProcessing.csproj" />
     <ProjectReference Include="..\QuantConnect.DataSource.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The JSON format of the QuiverQuant API has become
```
{
    "date": "yyyy-MM-dd",
    "follower": int,
    "pct_change_daily": float,
    "pct_change_week": float,
    "pct_change": float,
}
```

- Change data processor to adapt new JSON format
- Add unit test on that